### PR TITLE
RFC 7871

### DIFF
--- a/gdns/provider.go
+++ b/gdns/provider.go
@@ -6,8 +6,9 @@ import (
 
 // DNSQuestion represents a DNS question to be resolved by a DNS server
 type DNSQuestion struct {
-	Name string `json:"name,omitempty"`
-	Type uint16 `json:"type,omitempty"`
+	Name   string `json:"name,omitempty"`
+	Type   uint16 `json:"type,omitempty"`
+	Subnet *dns.EDNS0_SUBNET `json:"subnet,omitempty"`
 }
 
 // DNSRR represents a DNS record, part of a response to a DNSQuestion
@@ -45,7 +46,7 @@ type DNSResponse struct {
 	Question           []DNSQuestion
 	Answer             []DNSRR
 	Authority          []DNSRR
-	Extra              []DNSRR
+	Extra              []dns.RR
 	Truncated          bool
 	RecursionDesired   bool
 	RecursionAvailable bool

--- a/gdns/provider_google.go
+++ b/gdns/provider_google.go
@@ -250,7 +250,7 @@ func (g GDNSProvider) newRequest(q DNSQuestion) (*http.Request, error) {
 	if q.Subnet == nil {
 		qry.Add("edns_client_subnet", g.opts.EDNS)
 	} else {
-		qry.Add("edns_client_subnet", q.Subnet.Address.String())
+		qry.Add("edns_client_subnet", fmt.Sprintf("%s/%d", q.Subnet.Address.String(), q.Subnet.SourceNetmask))
 	}
 
 	httpreq.URL.RawQuery = qry.Encode()
@@ -292,7 +292,7 @@ func (g GDNSProvider) Query(q DNSQuestion) (*DNSResponse, error) {
 		return nil, err
 	}
 	extra := []dns.RR{}
-
+	
 	if q.Subnet != nil {
 		ip, ipNet, err := net.ParseCIDR(dnsResp.EDNSClientSubnet)
 		if err == nil {


### PR DESCRIPTION
**Accept client subnet provided in DNS query, and add the corresponding response.** 

dig with subnet [(web)](https://dns.google.com/query?name=www.taobao.com&type=A&dnssec=true&ecs=114.114.114.114%2F32), mainland IPs:    
```
; <<>> DiG 9.10.6 <<>> @127.0.0.1 www.taobao.com +subnet=114.114.114.114
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 9065
;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
; CLIENT-SUBNET: 114.114.114.114/32/24
;; QUESTION SECTION:
;www.taobao.com.                        IN      A

;; ANSWER SECTION:
www.taobao.com.         416     IN      CNAME   www.taobao.com.danuoyi.tbcache.com.
www.taobao.com.danuoyi.tbcache.com. 162 IN A    58.215.145.110
www.taobao.com.danuoyi.tbcache.com. 162 IN A    58.218.215.155
www.taobao.com.danuoyi.tbcache.com. 162 IN A    180.96.11.188
www.taobao.com.danuoyi.tbcache.com. 162 IN A    222.186.49.177

;; Query time: 76 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Wed Jan 03 17:29:12 China Standard Time 2018
;; MSG SIZE  rcvd: 317
```

dig without subnet, HK IP:    
```
; <<>> DiG 9.10.6 <<>> @127.0.0.1 www.taobao.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39972
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;www.taobao.com.                        IN      A

;; ANSWER SECTION:
www.taobao.com.         392     IN      CNAME   www.taobao.com.danuoyi.tbcache.com.
www.taobao.com.danuoyi.tbcache.com. 179 IN A    205.204.104.227

;; Query time: 92 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Wed Jan 03 17:29:18 China Standard Time 2018
;; MSG SIZE  rcvd: 144
```
  